### PR TITLE
Add id marker for drone in visualization

### DIFF
--- a/src/drones_visualization/include/drone_visual.hpp
+++ b/src/drones_visualization/include/drone_visual.hpp
@@ -32,6 +32,10 @@ public:
         return drone_id + "/visual/path";
     }
 
+    std::string getTextMarkersTopic() {
+        return std::string{"/text_markers"};
+    }
+
 private:
     void communicationInit();
 
@@ -50,6 +54,7 @@ private:
 
     MsgPathT path;
     MsgMarkerT marker;
+    MsgMarkerT text_marker;
     
     rclcpp::Publisher<MsgPathT>::SharedPtr pathPublisher;
     rclcpp::Publisher<MsgMarkerT>::SharedPtr markerPublisher;

--- a/src/drones_visualization/src/drone_visual.cpp
+++ b/src/drones_visualization/src/drone_visual.cpp
@@ -61,14 +61,27 @@ void DroneVisual::initMarker() {
     marker.id = std::stoi(drone_id.substr(drone_id.rfind('_') + 1));
     marker.type = MsgMarkerT::SPHERE;
     marker.action = MsgMarkerT::ADD;
-    marker.scale.x = 10.0; // Line width
-    marker.scale.y = 10.0; // Line width
-    marker.scale.z = 10.0; // Line width
-    marker.color.r = 1.0f; // Red color
+    marker.scale.x = 10.0;
+    marker.scale.y = 10.0;
+    marker.scale.z = 10.0;
+    marker.color.r = 1.0f;
     marker.color.g = 0.0f;
     marker.color.b = 0.0f;
-    marker.color.a = 1.0f; // Fully opaque
-    marker.lifetime = rclcpp::Duration(0, 0); // No lifetime
+    marker.color.a = 1.0f;
+    marker.lifetime = rclcpp::Duration(0, 0);
+
+    // Текстовая метка
+    text_marker.ns = "drones";
+    text_marker.id = marker.id + 1000; // уникальный id для текста
+    text_marker.type = MsgMarkerT::TEXT_VIEW_FACING;
+    text_marker.action = MsgMarkerT::ADD;
+    text_marker.scale.z = 8.0;
+    text_marker.color.r = 1.0f;
+    text_marker.color.g = 1.0f;
+    text_marker.color.b = 1.0f;
+    text_marker.color.a = 1.0f;
+    text_marker.lifetime = rclcpp::Duration(0, 0);
+    text_marker.text = drone_id;
 }
 
 void DroneVisual::updateMarker(const MsgDroneOdometryPtrT msg) {
@@ -76,6 +89,12 @@ void DroneVisual::updateMarker(const MsgDroneOdometryPtrT msg) {
     marker.pose.position.x = msg->pose.pose.position.x;
     marker.pose.position.y = msg->pose.pose.position.y;
     marker.pose.position.z = msg->pose.pose.position.z;
+
+    // Текстовая метка — выше сферы
+    text_marker.header = msg->header;
+    text_marker.pose.position.x = msg->pose.pose.position.x;
+    text_marker.pose.position.y = msg->pose.pose.position.y;
+    text_marker.pose.position.z = msg->pose.pose.position.z - marker.scale.z * 1.2;
 }
 
 void DroneVisual::updatePath(const MsgDroneOdometryPtrT msg) {
@@ -100,7 +119,8 @@ void DroneVisual::odometryHandler(const MsgDroneOdometryPtrT msg) {
     if (count++ % coeff == 0) {
         updateMarker(msg);
         markerPublisher->publish(marker);
-    
+        markerPublisher->publish(text_marker);
+
         updatePath(msg);
         pathPublisher->publish(path);
     }


### PR DESCRIPTION
This pull request introduces functionality for adding and managing text markers in the `DroneVisual` class, enhancing the visualization of drones with descriptive text. Key changes include the addition of a new topic for text markers, initialization of text marker properties, and updates to ensure text markers are published alongside existing markers.

### New Feature: Text Markers for Drone Visualization
* **Added `getTextMarkersTopic` method**: Introduced a new method to return the topic name for text markers (`/text_markers`). (`[src/drones_visualization/include/drone_visual.hppR35-R38](diffhunk://#diff-faa69217acf52682ebde446365d7a1002136072513c69f15c195abd716b61193R35-R38)`)
* **Added `text_marker` member**: Declared a new `MsgMarkerT` member for handling text markers in the `DroneVisual` class. (`[src/drones_visualization/include/drone_visual.hppR57](diffhunk://#diff-faa69217acf52682ebde446365d7a1002136072513c69f15c195abd716b61193R57)`)

### Text Marker Initialization and Updates
* **Initialized text marker properties in `initMarker`**: Configured text marker attributes such as namespace, unique ID, type, scale, color, and text content (drone ID). (`[src/drones_visualization/src/drone_visual.cppL64-R97](diffhunk://#diff-feaf87b7ac0b2a30948805f84db6891425535817805c14c6effa6581eadeb46dL64-R97)`)
* **Updated text marker position in `updateMarker`**: Positioned the text marker slightly above the sphere marker to ensure proper visualization. (`[src/drones_visualization/src/drone_visual.cppL64-R97](diffhunk://#diff-feaf87b7ac0b2a30948805f84db6891425535817805c14c6effa6581eadeb46dL64-R97)`)

### Publishing Text Markers
* **Published text markers in `odometryHandler`**: Ensured `text_marker` is published alongside the existing `marker` in the odometry handler. (`[src/drones_visualization/src/drone_visual.cppR122](diffhunk://#diff-feaf87b7ac0b2a30948805f84db6891425535817805c14c6effa6581eadeb46dR122)`)